### PR TITLE
Move comment into action

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -64,11 +64,3 @@ jobs:
         with:
           ovm-api-key: ${{ secrets.OVM_TOKEN }}
           plan-json: ./testmodule/tfplan.json
-
-      - name: post change url as sticky comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ !env.ACT && github.event_name == 'pull_request' }} # skip during local actions testing
-        with:
-          header: change
-          message: |
-            See the effect of your planned changes at [Overmind](${{ steps.submit-plan.outputs.change-url }})

--- a/submit-plan/action.yml
+++ b/submit-plan/action.yml
@@ -35,8 +35,7 @@ runs:
       env:
         OVM_API_KEY: ${{ inputs.ovm-api-key }}
       run: |
-        set -x
-        set -e
+        set -xe
 
         url=$(./overmindtech/ovm-cli submit-plan \
             --title '${{ github.event.pull_request.title }}' \

--- a/submit-plan/action.yml
+++ b/submit-plan/action.yml
@@ -11,6 +11,9 @@ inputs:
   plan-json:
     description: The location of the terraform plan file (generated from `terraform plan -out=...` and `terraform show -json ...`; defaults to `tfplan.json`)
     default: tfplan.json
+  log:
+    description: The log level for the job
+    default: info
 outputs:
   change-url:
     description: "The URL of the created change"
@@ -33,9 +36,21 @@ runs:
         OVM_API_KEY: ${{ inputs.ovm-api-key }}
       run: |
         set -x
-        echo change-url=$(./overmindtech/ovm-cli submit-plan \
+        set -e
+
+        url=$(./overmindtech/ovm-cli submit-plan \
             --title '${{ github.event.pull_request.title }}' \
             --description 'This change was automatically created from a PR' \
             --ticket-link '${{ github.event.pull_request.html_url }}' \
-            --plan-json '${{ inputs.plan-json }}') \
-            >> $GITHUB_OUTPUT
+            --plan-json '${{ inputs.plan-json }}' \
+            --log '${{ inputs.log }}')
+
+        echo "change-url=$url" >> $GITHUB_OUTPUT
+
+    - name: Post change url as sticky comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: ${{ steps.submit-plan.outputs.change-url != '' }}
+      with:
+        header: change
+        message: |
+          See the blast radius of your planned changes at [Overmind](${{ steps.submit-plan.outputs.change-url }})


### PR DESCRIPTION
This will allow us to contol the contents of the comment. I have also:

* Exposed the log level for debugging
* Made the action fail if the command fails

The fact that the action fails means that if we can't generate a blast radius we don't create a comment at all. Previously you still got a comment but the link was empty which resulted in it redirecting you back to the PR